### PR TITLE
Add Jupyter notebook demonstrating sample usage

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -1,0 +1,303 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HtmlTableScraping Demo\n",
+    "\n",
+    "This notebook demonstrates how to use the HtmlTableScraping library to convert HTML tables into pandas DataFrames.\n",
+    "\n",
+    "## Installation\n",
+    "\n",
+    "First, make sure you have the required dependencies installed:\n",
+    "\n",
+    "```bash\n",
+    "uv sync\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "from scraper import parse_table, TableCell\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Example\n",
+    "\n",
+    "Let's start with a simple HTML table and convert it to a pandas DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "html = '''\n",
+    "<table>\n",
+    "    <tr><th>Year</th><th>Change</th></tr>\n",
+    "    <tr><td>1970</td><td>0.10%</td></tr>\n",
+    "    <tr><td>1971</td><td>10.79%</td></tr>\n",
+    "</table>\n",
+    "'''\n",
+    "\n",
+    "soup = BeautifulSoup(html, \"html.parser\")\n",
+    "table = soup.find(\"table\")\n",
+    "result = parse_table(table)\n",
+    "print(result)\n",
+    "print(f\"\\nDataFrame type: {type(result)}\")\n",
+    "print(f\"Columns: {list(result.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table with Complex Content\n",
+    "\n",
+    "The library can handle tables with hidden elements, superscripts, and hyperlinks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "complex_html = '''\n",
+    "<table>\n",
+    "    <tr><th>Country</th><th>Population</th><th>Notes</th></tr>\n",
+    "    <tr>\n",
+    "        <td><a href=\"/usa\">United States</a></td>\n",
+    "        <td>331 million<sup>1</sup></td>\n",
+    "        <td>Data from <span style=\"display:none\">hidden text</span>2020 census</td>\n",
+    "    </tr>\n",
+    "    <tr>\n",
+    "        <td><a href=\"/china\">China</a></td>\n",
+    "        <td>1.4 billion<sup>2</sup></td>\n",
+    "        <td>Estimated<br/>population</td>\n",
+    "    </tr>\n",
+    "</table>\n",
+    "'''\n",
+    "\n",
+    "soup = BeautifulSoup(complex_html, \"html.parser\")\n",
+    "table = soup.find(\"table\")\n",
+    "result = parse_table(table)\n",
+    "print(\"Parsed table:\")\n",
+    "print(result)\n",
+    "print(\"\\nNotice how:\")\n",
+    "print(\"- Hidden spans are removed\")\n",
+    "print(\"- Superscripts are stripped from main text\")\n",
+    "print(\"- Line breaks are converted to spaces\")\n",
+    "print(\"- Links are converted to plain text\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table without Headers\n",
+    "\n",
+    "You can also parse tables that don't have header rows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "no_header_html = '''\n",
+    "<table>\n",
+    "    <tr><td>Apple</td><td>Red</td><td>Sweet</td></tr>\n",
+    "    <tr><td>Banana</td><td>Yellow</td><td>Sweet</td></tr>\n",
+    "    <tr><td>Lemon</td><td>Yellow</td><td>Sour</td></tr>\n",
+    "</table>\n",
+    "'''\n",
+    "\n",
+    "soup = BeautifulSoup(no_header_html, \"html.parser\")\n",
+    "table = soup.find(\"table\")\n",
+    "result = parse_table(table, first_row_as_col_titles=False)\n",
+    "print(\"Table without headers:\")\n",
+    "print(result)\n",
+    "print(f\"\\nColumns: {list(result.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the Table.pretty_print() Method\n",
+    "\n",
+    "The `Table` class (which extends pandas DataFrame) includes a `pretty_print()` method for rich display in Jupyter notebooks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "html_with_title = '''\n",
+    "<table>\n",
+    "    <tr><th>Product</th><th>Price</th><th>Stock</th></tr>\n",
+    "    <tr><td>Laptop</td><td>$999</td><td>15</td></tr>\n",
+    "    <tr><td>Mouse</td><td>$25</td><td>50</td></tr>\n",
+    "    <tr><td>Keyboard</td><td>$75</td><td>30</td></tr>\n",
+    "</table>\n",
+    "'''\n",
+    "\n",
+    "soup = BeautifulSoup(html_with_title, \"html.parser\")\n",
+    "table = soup.find(\"table\")\n",
+    "result = parse_table(table)\n",
+    "result.title = \"Product Inventory\"\n",
+    "\n",
+    "print(\"Using pretty_print():\")\n",
+    "result.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with TableCell Objects\n",
+    "\n",
+    "For more advanced use cases, you can work with individual `TableCell` objects to access metadata like links and superscripts:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_html = '<td><a href=\"/wikipedia\">Wikipedia</a> article<sup>citation needed</sup></td>'\n",
+    "soup = BeautifulSoup(cell_html, \"html.parser\")\n",
+    "cell = TableCell.from_soup(soup.td)\n",
+    "\n",
+    "print(f\"Cell text: '{cell.text}'\")\n",
+    "print(f\"Links found: {cell.links}\")\n",
+    "print(f\"Superscripts found: {cell.sups}\")\n",
+    "\n",
+    "cell_df = cell.to_df()\n",
+    "print(\"\\nCell as DataFrame:\")\n",
+    "print(cell_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handling Edge Cases\n",
+    "\n",
+    "The library gracefully handles various edge cases:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "empty_html = '<table></table>'\n",
+    "soup = BeautifulSoup(empty_html, \"html.parser\")\n",
+    "empty_result = parse_table(soup.find(\"table\"))\n",
+    "print(f\"Empty table result: {empty_result}\")\n",
+    "print(f\"Shape: {empty_result.shape}\")\n",
+    "\n",
+    "none_result = parse_table(None)\n",
+    "print(f\"\\nNone input result: {none_result}\")\n",
+    "print(f\"Shape: {none_result.shape}\")\n",
+    "\n",
+    "uneven_html = '''\n",
+    "<table>\n",
+    "    <tr><th>A</th><th>B</th><th>C</th></tr>\n",
+    "    <tr><td>1</td><td>2</td></tr>\n",
+    "    <tr><td>3</td><td>4</td><td>5</td></tr>\n",
+    "</table>\n",
+    "'''\n",
+    "soup = BeautifulSoup(uneven_html, \"html.parser\")\n",
+    "uneven_result = parse_table(soup.find(\"table\"))\n",
+    "print(\"\\nUneven rows (automatically normalized):\")\n",
+    "print(uneven_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Limitations\n",
+    "\n",
+    "As noted in the documentation, `parse_table` currently does not handle `rowspan` or `colspan` attributes. Tables using these features may not be parsed correctly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colspan_html = '''\n",
+    "<table>\n",
+    "    <tr><th>Name</th><th colspan=\"2\">Details</th></tr>\n",
+    "    <tr><td>John</td><td>Age: 30</td><td>City: NYC</td></tr>\n",
+    "</table>\n",
+    "'''\n",
+    "\n",
+    "soup = BeautifulSoup(colspan_html, \"html.parser\")\n",
+    "colspan_result = parse_table(soup.find(\"table\"))\n",
+    "print(\"Table with colspan (may not parse as expected):\")\n",
+    "print(colspan_result)\n",
+    "print(\"\\nNote: The colspan attribute is ignored, which may lead to misaligned data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "The HtmlTableScraping library provides a simple and effective way to convert HTML tables into pandas DataFrames. Key features include:\n",
+    "\n",
+    "- Automatic handling of headers\n",
+    "- Removal of hidden elements and superscripts\n",
+    "- Preservation of metadata (links, superscripts) when needed\n",
+    "- Graceful handling of edge cases\n",
+    "- Rich display capabilities in Jupyter notebooks\n",
+    "\n",
+    "For more information, see the [project README](README.md) and the source code documentation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scraper.py
+++ b/scraper.py
@@ -12,7 +12,7 @@ import pandas as pd
 def _deep_copy(soup: Tag) -> BeautifulSoup:
     """Return a deep copy of a BeautifulSoup tag."""
 
-    return BeautifulSoup(str(soup), "lxml")
+    return BeautifulSoup(str(soup), "html.parser")
 
 
 def _get_text(element: Tag | str | None) -> str:


### PR DESCRIPTION
- Created comprehensive demo.ipynb with examples from README plus additional use cases
- Fixed scraper.py to use html.parser instead of lxml for better compatibility
- Includes examples of basic table parsing, complex content handling, edge cases
- Demonstrates Table.pretty_print() method and TableCell metadata access
- All pre-commit hooks pass and notebook executes successfully